### PR TITLE
Spotify card responsiveness

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -41,6 +41,7 @@ const App = () => {
   const [token, setToken] = useState("");
   const [currentTrackUri, setCurrentTrackUri] = useState(null);
   const [userLocation, setUserLocation] = useState(null);
+  const [showPlayer, setShowPlayer] = useState(false);
 
   useEffect(() => {
     const extractTokensFromURL = () => {
@@ -121,6 +122,16 @@ const App = () => {
     return () => clearInterval(interval);
   }, []);
 
+  const handleTrackChange = (uri) => {
+    setCurrentTrackUri(uri);
+    setShowPlayer(true);
+  };
+
+  const handleClosePlayer = () => {
+    setShowPlayer(false);
+    setCurrentTrackUri(null);
+  };
+
   return (
     <Router>
       <div className="Home">
@@ -144,7 +155,7 @@ const App = () => {
             path="/home"
             element={
               <ProtectedRoute>
-                <Home token={token} setCurrentTrackUri={setCurrentTrackUri} />
+                <Home token={token} setCurrentTrackUri={handleTrackChange} />
               </ProtectedRoute>
             }
           />
@@ -197,7 +208,7 @@ const App = () => {
                 >
                   <CategoryPage
                     token={token}
-                    setCurrentTrackUri={setCurrentTrackUri}
+                    setCurrentTrackUri={handleTrackChange}
                   />
                 </Suspense>
               </ProtectedRoute>
@@ -216,7 +227,7 @@ const App = () => {
                 >
                   <Playlist
                     token={token}
-                    setCurrentTrackUri={setCurrentTrackUri}
+                    setCurrentTrackUri={handleTrackChange}
                   />
                 </Suspense>
               </ProtectedRoute>
@@ -235,15 +246,19 @@ const App = () => {
                 >
                   <ArtistPage
                     token={token}
-                    setCurrentTrackUri={setCurrentTrackUri}
+                    setCurrentTrackUri={handleTrackChange}
                   />
                 </Suspense>
               </ProtectedRoute>
             }
           />
         </Routes>
-        {token && currentTrackUri && (
-          <SpotifyPlayer token={token} trackUri={currentTrackUri} />
+        {showPlayer && token && currentTrackUri && (
+          <SpotifyPlayer
+            token={token}
+            trackUri={currentTrackUri}
+            onClose={handleClosePlayer}
+          />
         )}
       </div>
     </Router>

--- a/client/src/components/Home/Media/SpotifyPlayer.css
+++ b/client/src/components/Home/Media/SpotifyPlayer.css
@@ -77,7 +77,7 @@
   margin-right: 20px;
   position: relative;
   bottom: 20px;
-  left: 400px;
+  left: 600px;
 }
 
 .spotify-player-button {
@@ -247,7 +247,17 @@
 }
 
 /* Responsive design */
+
+@media (max-width: 1600px) {
+  .spotify-player-controls {
+    left: 130px;
+  }
+}
+
 @media (max-width: 1200px) {
+  .spotify-player-close-button {
+    display: none;
+  }
   .spotify-player-info {
     width: 400px;
   }
@@ -262,6 +272,9 @@
 }
 
 @media (max-width: 992px) {
+  .spotify-player-close-button {
+    display: none;
+  }
   .spotify-player-info {
     width: 300px;
   }
@@ -280,6 +293,9 @@
 }
 
 @media (max-width: 768px) {
+  .spotify-player-close-button {
+    display: none;
+  }
   .spotify-player {
     flex-direction: column;
     height: 100px;
@@ -311,6 +327,9 @@
 }
 
 @media (max-width: 576px) {
+  .spotify-player-close-button {
+    display: none;
+  }
   .spotify-player-info img {
     width: 60px;
     height: 10px;

--- a/client/src/components/Home/Media/SpotifyPlayer.css
+++ b/client/src/components/Home/Media/SpotifyPlayer.css
@@ -231,3 +231,120 @@
   cursor: pointer;
   margin-top: 10px;
 }
+
+.spotify-player-close-button {
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  position: absolute;
+  top: 10px;
+  right: 300px;
+}
+
+.spotify-player-close-button:hover .spotify-player-icon {
+  color: #f00;
+}
+
+/* Responsive design */
+@media (max-width: 1200px) {
+  .spotify-player-info {
+    width: 400px;
+  }
+
+  .spotify-player-controls {
+    left: 70px;
+  }
+
+  .spotify-player-progress {
+    width: 50%;
+  }
+}
+
+@media (max-width: 992px) {
+  .spotify-player-info {
+    width: 300px;
+  }
+
+  .spotify-player-controls {
+    left: 30px;
+  }
+
+  .spotify-player-progress {
+    width: 40%;
+  }
+
+  .player-track-name {
+    font-size: 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  .spotify-player {
+    flex-direction: column;
+    height: 100px;
+    padding: 10px 20px;
+  }
+
+  .spotify-player-info {
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 10px;
+  }
+
+  .spotify-player-controls {
+    position: relative;
+    bottom: 0;
+    left: 0;
+    margin-bottom: 10px;
+  }
+
+  .spotify-player-progress {
+    width: 80%;
+    right: 0;
+    bottom: 0;
+  }
+
+  .player-track-name {
+    font-size: 18px;
+  }
+}
+
+@media (max-width: 576px) {
+  .spotify-player-info img {
+    width: 60px;
+    height: 10px;
+    margin: 10px;
+  }
+
+  .spotify-player-info {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .spotify-player-controls {
+    margin-bottom: 10px;
+  }
+
+  .spotify-player-progress {
+    width: 100%;
+    padding: 0 20px;
+  }
+
+  .player-track-name {
+    font-size: 16px;
+  }
+
+  .spotify-player-button {
+    margin: 0 10px;
+  }
+
+  .spotify-player-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .progress-bar {
+    margin: 5px;
+  }
+}

--- a/client/src/components/Home/Media/SpotifyPlayer.jsx
+++ b/client/src/components/Home/Media/SpotifyPlayer.jsx
@@ -7,10 +7,11 @@ import {
   RewindIcon,
   VolumeUpIcon,
   PlusIcon,
+  XIcon,
 } from "@heroicons/react/solid";
 import "./SpotifyPlayer.css";
 
-const SpotifyPlayer = ({ token, trackUri }) => {
+const SpotifyPlayer = ({ token, trackUri, onClose }) => {
   const [player, setPlayer] = useState(null);
   const [isPaused, setIsPaused] = useState(true);
   const [deviceId, setDeviceId] = useState(null);
@@ -97,6 +98,9 @@ const SpotifyPlayer = ({ token, trackUri }) => {
     return () => {
       if (intervalId) {
         clearInterval(intervalId);
+      }
+      if (player) {
+        player.disconnect();
       }
     };
   }, [token, intervalId]);
@@ -209,6 +213,14 @@ const SpotifyPlayer = ({ token, trackUri }) => {
     setShowPlaylists(false);
   };
 
+  const handleProgressChange = (e) => {
+    const newPosition = e.target.value;
+    setProgress(newPosition);
+    if (player) {
+      player.seek(newPosition);
+    }
+  };
+
   const formatTime = (milliseconds) => {
     const minutes = Math.floor(milliseconds / 60000);
     const seconds = ((milliseconds % 60000) / 1000).toFixed(0);
@@ -297,7 +309,7 @@ const SpotifyPlayer = ({ token, trackUri }) => {
             min="0"
             max={duration}
             value={progress}
-            onChange={(e) => setProgress(e.target.value)}
+            onChange={handleProgressChange}
             className="progress-bar"
           />
           <span>{formatTime(duration - progress)}</span>
@@ -314,6 +326,9 @@ const SpotifyPlayer = ({ token, trackUri }) => {
           className="volume-bar"
         />
       </div>
+      <button onClick={onClose} className="spotify-player-close-button">
+        <XIcon className="spotify-player-icon" />
+      </button>
     </div>
   );
 };
@@ -321,6 +336,7 @@ const SpotifyPlayer = ({ token, trackUri }) => {
 SpotifyPlayer.propTypes = {
   token: PropTypes.string.isRequired,
   trackUri: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default SpotifyPlayer;


### PR DESCRIPTION
Made an on-click close element to close the Spotify player and made the it playfully responsive for all device sizes 
I added a useState hook in the app.jsx to store the state of the Spotify player and passed it down to the player component where it is used to manage the player state

I used the @media in the CSS file  to define the type it should adapt when the screen size changes